### PR TITLE
add missing "Unit" section to the siad.service

### DIFF
--- a/pages/guides/sia/linux-hosting.en.md
+++ b/pages/guides/sia/linux-hosting.en.md
@@ -23,6 +23,7 @@ $ sudo nano /etc/systemd/system/siad.service
 Then, modify the following snippet to fit your host and then paste it into the file. You will want to change `asecurewalletpassword` to a more secure wallet password.
 
 ```
+[Unit]
 Description=siad
 After=network.target
 


### PR DESCRIPTION
the siad.service contains assignments which belong to the Unit section, but the section is not present